### PR TITLE
Sort generated code 

### DIFF
--- a/example/proto/go/service/v1/service.go
+++ b/example/proto/go/service/v1/service.go
@@ -33,16 +33,16 @@ func NewValidator() Validator { return validator{} }
 type Validator interface {
 	Name() string
 	ValidateBiking(*publicpb.Biking) error
-	ValidateGetRequest(*publicpb.GetRequest) error
-	ValidateListRequest(*publicpb.ListRequest) error
-	ValidatePerson(*publicpb.Person) error
 	ValidateCoding(*publicpb.Coding) error
 	ValidateCreateRequest(*publicpb.CreateRequest) error
 	ValidateDeleteRequest(*publicpb.DeleteRequest) error
+	ValidateGetRequest(*publicpb.GetRequest) error
 	ValidateHobby(*publicpb.Hobby) error
 	ValidateHobby_Coding(*publicpb.Hobby_Coding) error
 	ValidateHobby_Reading(*publicpb.Hobby_Reading) error
 	ValidateHobby_Biking(*publicpb.Hobby_Biking) error
+	ValidateListRequest(*publicpb.ListRequest) error
+	ValidatePerson(*publicpb.Person) error
 	ValidateReading(*publicpb.Reading) error
 }
 type validator struct{}
@@ -54,44 +54,6 @@ func (v validator) ValidateBiking(in *publicpb.Biking) error {
 	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Style),
-	)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-func (v validator) ValidateGetRequest(in *publicpb.GetRequest) error {
-	err := validation.ValidateStruct(in,
-		validation.Field(&in.Id,
-			validation.Required,
-			is.UUID,
-		),
-	)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-func (v validator) ValidateListRequest(in *publicpb.ListRequest) error {
-	err := validation.ValidateStruct(in)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-func (v validator) ValidatePerson(in *publicpb.Person) error {
-	if in == nil {
-		return nil
-	}
-	err := validation.ValidateStruct(in,
-		validation.Field(&in.Id),
-		validation.Field(&in.FirstName),
-		validation.Field(&in.LastName),
-		validation.Field(&in.Employment),
-		validation.Field(&in.Hobby,
-			validation.Required,
-			validation.By(func(interface{}) error { return v.ValidateHobby(in.Hobby) }),
-		),
 	)
 	if err != nil {
 		return err
@@ -136,6 +98,18 @@ func (v validator) ValidateCreateRequest(in *publicpb.CreateRequest) error {
 	return nil
 }
 func (v validator) ValidateDeleteRequest(in *publicpb.DeleteRequest) error {
+	err := validation.ValidateStruct(in,
+		validation.Field(&in.Id,
+			validation.Required,
+			is.UUID,
+		),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (v validator) ValidateGetRequest(in *publicpb.GetRequest) error {
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,
@@ -212,6 +186,32 @@ func (v validator) ValidateHobby_Biking(in *publicpb.Hobby_Biking) error {
 	}
 	return nil
 }
+func (v validator) ValidateListRequest(in *publicpb.ListRequest) error {
+	err := validation.ValidateStruct(in)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (v validator) ValidatePerson(in *publicpb.Person) error {
+	if in == nil {
+		return nil
+	}
+	err := validation.ValidateStruct(in,
+		validation.Field(&in.Id),
+		validation.Field(&in.FirstName),
+		validation.Field(&in.LastName),
+		validation.Field(&in.Employment),
+		validation.Field(&in.Hobby,
+			validation.Required,
+			validation.By(func(interface{}) error { return v.ValidateHobby(in.Hobby) }),
+		),
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}
 func (v validator) ValidateReading(in *publicpb.Reading) error {
 	if in == nil {
 		return nil
@@ -233,19 +233,19 @@ type Converter interface {
 	Name() string
 	ToNextCreateRequest(*publicpb.CreateRequest) *nextpb.CreateRequest
 	ToPublicCreateResponse(*nextpb.CreateResponse, *privatepb.CreateResponse) (*publicpb.CreateResponse, error)
-	ToNextGetRequest(*publicpb.GetRequest) *nextpb.GetRequest
-	ToPublicGetResponse(*nextpb.GetResponse, *privatepb.FetchResponse) (*publicpb.GetResponse, error)
 	ToNextDeleteRequest(*publicpb.DeleteRequest) *nextpb.DeleteRequest
 	ToPublicDeleteResponse(*nextpb.DeleteResponse, *privatepb.DeleteResponse) (*publicpb.DeleteResponse, error)
+	ToNextGetRequest(*publicpb.GetRequest) *nextpb.GetRequest
+	ToPublicGetResponse(*nextpb.GetResponse, *privatepb.FetchResponse) (*publicpb.GetResponse, error)
 	ToPrivateListRequest(*publicpb.ListRequest) *privatepb.ListRequest
 	ToNextCycling(*publicpb.Biking) *nextpb.Cycling
 	ToPublicBiking(*nextpb.Cycling, *privatepb.Cycling) (*publicpb.Biking, error)
-	ToNextPerson(*publicpb.Person) *nextpb.Person
-	ToPublicPerson(*nextpb.Person, *privatepb.Person) (*publicpb.Person, error)
 	ToNextCoding(*publicpb.Coding) *nextpb.Coding
 	ToPublicCoding(*nextpb.Coding, *privatepb.Coding) (*publicpb.Coding, error)
 	ToNextHobby(*publicpb.Hobby) *nextpb.Hobby
 	ToPublicHobby(*nextpb.Hobby, *privatepb.Hobby) (*publicpb.Hobby, error)
+	ToNextPerson(*publicpb.Person) *nextpb.Person
+	ToPublicPerson(*nextpb.Person, *privatepb.Person) (*publicpb.Person, error)
 	ToNextReading(*publicpb.Reading) *nextpb.Reading
 	ToPublicReading(*nextpb.Reading, *privatepb.Reading) (*publicpb.Reading, error)
 	ToNextPerson_Employment(publicpb.Person_Employment) nextpb.Person_Employment
@@ -287,6 +287,26 @@ func (c converter) ToPublicCreateResponse(nextIn *nextpb.CreateResponse, private
 	}
 	return &out, err
 }
+func (c converter) ToNextDeleteRequest(in *publicpb.DeleteRequest) *nextpb.DeleteRequest {
+	if in == nil {
+		return nil
+	}
+	var out nextpb.DeleteRequest
+	out.Id = in.Id
+	return &out
+}
+func (c converter) ToPublicDeleteResponse(nextIn *nextpb.DeleteResponse, privateIn *privatepb.DeleteResponse) (*publicpb.DeleteResponse, error) {
+	if nextIn == nil || privateIn == nil {
+		return nil, nil
+	}
+	required := validation.Errors{}
+	if err := required.Filter(); err != nil {
+		return nil, err
+	}
+	var out publicpb.DeleteResponse
+	var err error
+	return &out, err
+}
 func (c converter) ToNextGetRequest(in *publicpb.GetRequest) *nextpb.GetRequest {
 	if in == nil {
 		return nil
@@ -309,26 +329,6 @@ func (c converter) ToPublicGetResponse(nextIn *nextpb.GetResponse, privateIn *pr
 	if err != nil {
 		return nil, err
 	}
-	return &out, err
-}
-func (c converter) ToNextDeleteRequest(in *publicpb.DeleteRequest) *nextpb.DeleteRequest {
-	if in == nil {
-		return nil
-	}
-	var out nextpb.DeleteRequest
-	out.Id = in.Id
-	return &out
-}
-func (c converter) ToPublicDeleteResponse(nextIn *nextpb.DeleteResponse, privateIn *privatepb.DeleteResponse) (*publicpb.DeleteResponse, error) {
-	if nextIn == nil || privateIn == nil {
-		return nil, nil
-	}
-	required := validation.Errors{}
-	if err := required.Filter(); err != nil {
-		return nil, err
-	}
-	var out publicpb.DeleteResponse
-	var err error
 	return &out, err
 }
 func (c converter) ToPrivateListRequest(in *publicpb.ListRequest) *privatepb.ListRequest {
@@ -357,47 +357,6 @@ func (c converter) ToPublicBiking(nextIn *nextpb.Cycling, privateIn *privatepb.C
 	var out publicpb.Biking
 	var err error
 	out.Style = nextIn.Style
-	return &out, err
-}
-func (c converter) ToNextPerson(in *publicpb.Person) *nextpb.Person {
-	if in == nil {
-		return nil
-	}
-	var out nextpb.Person
-	out.Id = in.Id
-	out.Employment = c.ToNextPerson_Employment(in.Employment)
-	out.CreatedAt = in.CreatedAt
-	out.UpdatedAt = in.UpdatedAt
-	out.Hobby = c.ToNextHobby(in.Hobby)
-	return &out
-}
-func (c converter) ToPublicPerson(nextIn *nextpb.Person, privateIn *privatepb.Person) (*publicpb.Person, error) {
-	if nextIn == nil || privateIn == nil {
-		return nil, nil
-	}
-	required := validation.Errors{}
-	required["Id"] = validation.Validate(nextIn.Id, validation.Required)
-	required["FirstName"] = validation.Validate(privateIn.FirstName, validation.Required)
-	required["LastName"] = validation.Validate(privateIn.LastName, validation.Required)
-	required["Employment"] = validation.Validate(nextIn.Employment, validation.Required)
-	if err := required.Filter(); err != nil {
-		return nil, err
-	}
-	var out publicpb.Person
-	var err error
-	out.Id = nextIn.Id
-	out.FirstName = privateIn.FirstName
-	out.LastName = privateIn.LastName
-	out.Employment, err = c.ToPublicPerson_Employment(nextIn.Employment)
-	if err != nil {
-		return nil, err
-	}
-	out.CreatedAt = nextIn.CreatedAt
-	out.UpdatedAt = nextIn.UpdatedAt
-	out.Hobby, err = c.ToPublicHobby(nextIn.Hobby, privateIn.Hobby)
-	if err != nil {
-		return nil, err
-	}
 	return &out, err
 }
 func (c converter) ToNextCoding(in *publicpb.Coding) *nextpb.Coding {
@@ -465,6 +424,47 @@ func (c converter) ToPublicHobby(nextIn *nextpb.Hobby, privateIn *privatepb.Hobb
 		var value publicpb.Hobby_Biking
 		value.Biking, err = c.ToPublicBiking(nextIn.GetCycling(), privateIn.GetCycling())
 		out.Type = &value
+	}
+	return &out, err
+}
+func (c converter) ToNextPerson(in *publicpb.Person) *nextpb.Person {
+	if in == nil {
+		return nil
+	}
+	var out nextpb.Person
+	out.Id = in.Id
+	out.Employment = c.ToNextPerson_Employment(in.Employment)
+	out.CreatedAt = in.CreatedAt
+	out.UpdatedAt = in.UpdatedAt
+	out.Hobby = c.ToNextHobby(in.Hobby)
+	return &out
+}
+func (c converter) ToPublicPerson(nextIn *nextpb.Person, privateIn *privatepb.Person) (*publicpb.Person, error) {
+	if nextIn == nil || privateIn == nil {
+		return nil, nil
+	}
+	required := validation.Errors{}
+	required["Id"] = validation.Validate(nextIn.Id, validation.Required)
+	required["FirstName"] = validation.Validate(privateIn.FirstName, validation.Required)
+	required["LastName"] = validation.Validate(privateIn.LastName, validation.Required)
+	required["Employment"] = validation.Validate(nextIn.Employment, validation.Required)
+	if err := required.Filter(); err != nil {
+		return nil, err
+	}
+	var out publicpb.Person
+	var err error
+	out.Id = nextIn.Id
+	out.FirstName = privateIn.FirstName
+	out.LastName = privateIn.LastName
+	out.Employment, err = c.ToPublicPerson_Employment(nextIn.Employment)
+	if err != nil {
+		return nil, err
+	}
+	out.CreatedAt = nextIn.CreatedAt
+	out.UpdatedAt = nextIn.UpdatedAt
+	out.Hobby, err = c.ToPublicHobby(nextIn.Hobby, privateIn.Hobby)
+	if err != nil {
+		return nil, err
 	}
 	return &out, err
 }
@@ -652,18 +652,18 @@ func (s *Service) Create(ctx context.Context, in *publicpb.CreateRequest) (*publ
 	out, _, err := s.CreateImpl(ctx, in)
 	return out, err
 }
-func (s *Service) Get(ctx context.Context, in *publicpb.GetRequest) (*publicpb.GetResponse, error) {
-	if err := s.ValidateGetRequest(in); err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
-	}
-	out, _, err := s.GetImpl(ctx, in)
-	return out, err
-}
 func (s *Service) Delete(ctx context.Context, in *publicpb.DeleteRequest) (*publicpb.DeleteResponse, error) {
 	if err := s.ValidateDeleteRequest(in); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
 	}
 	out, _, err := s.DeleteImpl(ctx, in)
+	return out, err
+}
+func (s *Service) Get(ctx context.Context, in *publicpb.GetRequest) (*publicpb.GetResponse, error) {
+	if err := s.ValidateGetRequest(in); err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "%s", err)
+	}
+	out, _, err := s.GetImpl(ctx, in)
 	return out, err
 }
 func (s *Service) List(ctx context.Context, in *publicpb.ListRequest) (*publicpb.ListResponse, error) {
@@ -687,18 +687,6 @@ func (s *Service) CreateImpl(ctx context.Context, in *publicpb.CreateRequest, mu
 	}
 	return out, privateOut, nil
 }
-func (s *Service) GetImpl(ctx context.Context, in *publicpb.GetRequest, mutators ...private.FetchRequestMutator) (*publicpb.GetResponse, *privatepb.FetchResponse, error) {
-	nextIn := s.ToNextGetRequest(in)
-	nextOut, privateOut, err := s.Next.GetImpl(ctx, nextIn, mutators...)
-	if err != nil {
-		return nil, nil, err
-	}
-	out, err := s.ToPublicGetResponse(nextOut, privateOut)
-	if err != nil {
-		return nil, nil, status.Errorf(codes.FailedPrecondition, "%s", err)
-	}
-	return out, privateOut, nil
-}
 func (s *Service) DeleteImpl(ctx context.Context, in *publicpb.DeleteRequest, mutators ...private.DeleteRequestMutator) (*publicpb.DeleteResponse, *privatepb.DeleteResponse, error) {
 	nextIn := s.ToNextDeleteRequest(in)
 	nextOut, privateOut, err := s.Next.DeleteImpl(ctx, nextIn, mutators...)
@@ -706,6 +694,18 @@ func (s *Service) DeleteImpl(ctx context.Context, in *publicpb.DeleteRequest, mu
 		return nil, nil, err
 	}
 	out, err := s.ToPublicDeleteResponse(nextOut, privateOut)
+	if err != nil {
+		return nil, nil, status.Errorf(codes.FailedPrecondition, "%s", err)
+	}
+	return out, privateOut, nil
+}
+func (s *Service) GetImpl(ctx context.Context, in *publicpb.GetRequest, mutators ...private.FetchRequestMutator) (*publicpb.GetResponse, *privatepb.FetchResponse, error) {
+	nextIn := s.ToNextGetRequest(in)
+	nextOut, privateOut, err := s.Next.GetImpl(ctx, nextIn, mutators...)
+	if err != nil {
+		return nil, nil, err
+	}
+	out, err := s.ToPublicGetResponse(nextOut, privateOut)
 	if err != nil {
 		return nil, nil, status.Errorf(codes.FailedPrecondition, "%s", err)
 	}

--- a/internal/finders.go
+++ b/internal/finders.go
@@ -402,31 +402,3 @@ func (d deprecatedFinder) sortedEnums() []*protogen.Enum {
 	sort.Sort(byEnumName(enums))
 	return enums
 }
-
-type byMessageName []*protogen.Message
-
-func (s byMessageName) Len() int {
-	return len(s)
-}
-
-func (s byMessageName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s byMessageName) Less(i, j int) bool {
-	return s[i].GoIdent.GoName < s[j].GoIdent.GoName
-}
-
-type byEnumName []*protogen.Enum
-
-func (s byEnumName) Len() int {
-	return len(s)
-}
-
-func (s byEnumName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s byEnumName) Less(i, j int) bool {
-	return s[i].GoIdent.GoName < s[j].GoIdent.GoName
-}

--- a/internal/generator.go
+++ b/internal/generator.go
@@ -174,6 +174,22 @@ func (g *Generator) Run(plugin *protogen.Plugin) error {
 		}
 	}
 
+	// Sort methods, messages, enums, fields and oneofs
+	for _, service := range services {
+		sort.Sort(byMethodName(service.Methods))
+		sort.Sort(byMessageName(service.Messages))
+		sort.Sort(byEnumName(service.Enums))
+
+		for _, message := range service.Messages {
+			sort.Sort(byFieldNumber(message.Fields))
+			sort.Sort(byOneofName(message.Oneofs))
+
+			for _, oneof := range message.Oneofs {
+				sort.Sort(byFieldNumber(oneof.Fields))
+			}
+		}
+	}
+
 	serviceLen := len(services)
 	for i, service := range services {
 		logger.Printf("package=%s at=generate-service", service.GoPackageName)

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -7,20 +7,6 @@ import (
 	"google.golang.org/protobuf/compiler/protogen"
 )
 
-type byPackageName []*Service
-
-func (s byPackageName) Len() int {
-	return len(s)
-}
-
-func (s byPackageName) Swap(i, j int) {
-	s[i], s[j] = s[j], s[i]
-}
-
-func (s byPackageName) Less(i, j int) bool {
-	return s[i].GoPackageName < s[j].GoPackageName
-}
-
 func serviceImportPath(service *Service) protogen.GoImportPath {
 	prefix := strings.TrimSuffix(string(service.GoIdent.GoImportPath), fmt.Sprintf("/%s", service.GoPackageName))
 	path := fmt.Sprintf("%s/service/%s", prefix, service.GoPackageName)

--- a/internal/sort.go
+++ b/internal/sort.go
@@ -1,0 +1,108 @@
+package internal
+
+import "google.golang.org/protobuf/compiler/protogen"
+
+// byPackageName sort services by package name
+type byPackageName []*Service
+
+func (s byPackageName) Len() int {
+	return len(s)
+}
+
+func (s byPackageName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byPackageName) Less(i, j int) bool {
+	return s[i].GoPackageName < s[j].GoPackageName
+}
+
+// byMethodName sort methods by name.
+type byMethodName []*protogen.Method
+
+func (s byMethodName) Len() int {
+	return len(s)
+}
+
+func (s byMethodName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byMethodName) Less(i, j int) bool {
+	return s[i].GoName < s[j].GoName
+}
+
+// byMessageName sort messages by name.
+type byMessageName []*protogen.Message
+
+func (s byMessageName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byMessageName) Less(i, j int) bool {
+	return s[i].GoIdent.GoName < s[j].GoIdent.GoName
+}
+
+func (s byMessageName) Len() int {
+	return len(s)
+}
+
+// byFieldNumber sort fields by position number.
+type byFieldNumber []*protogen.Field
+
+func (s byFieldNumber) Len() int {
+	return len(s)
+}
+
+func (s byFieldNumber) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byFieldNumber) Less(i, j int) bool {
+	return s[i].Desc.Number() < s[j].Desc.Number()
+}
+
+// byEnumName sort enums by name.
+type byEnumName []*protogen.Enum
+
+func (s byEnumName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byEnumName) Less(i, j int) bool {
+	return s[i].GoIdent.GoName < s[j].GoIdent.GoName
+}
+
+func (s byEnumName) Len() int {
+	return len(s)
+}
+
+// byEnumValueNumber sort enum values by position number.
+type byEnumValueNumber []*protogen.EnumValue
+
+func (s byEnumValueNumber) Len() int {
+	return len(s)
+}
+
+func (s byEnumValueNumber) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byEnumValueNumber) Less(i, j int) bool {
+	return s[i].Desc.Number() < s[j].Desc.Number()
+}
+
+// byOneofName sort oneofs by name.
+type byOneofName []*protogen.Oneof
+
+func (s byOneofName) Swap(i, j int) {
+	s[i], s[j] = s[j], s[i]
+}
+
+func (s byOneofName) Less(i, j int) bool {
+	return s[i].GoIdent.GoName < s[j].GoIdent.GoName
+}
+
+func (s byOneofName) Len() int {
+	return len(s)
+}


### PR DESCRIPTION
Types should be sorted to reduce the diff when regenerating services. This will also make it possible to verify in CI that proto files weren't changed without running `protoc`.