### PR TITLE
Generate service mutators with text/template package

### DIFF
--- a/example/proto/go/service/private/service.go
+++ b/example/proto/go/service/private/service.go
@@ -286,6 +286,12 @@ func (v validator) ValidateUpdateRequest(in *privatepb.UpdateRequest) error {
 
 type CreateRequestMutator func(*privatepb.CreateRequest)
 
+func ApplyCreateRequestMutators(in *privatepb.CreateRequest, mutators []CreateRequestMutator) {
+	for _, mutator := range mutators {
+		mutator(in)
+	}
+}
+
 func SetCreateRequest_Id(value string) CreateRequestMutator {
 	return func(in *privatepb.CreateRequest) {
 		in.Id = value
@@ -321,35 +327,32 @@ func SetCreateRequest_Hobby(value *privatepb.Hobby) CreateRequestMutator {
 		in.Hobby = value
 	}
 }
-func ApplyCreateRequestMutators(in *privatepb.CreateRequest, mutators []CreateRequestMutator) {
-	for _, mutator := range mutators {
-		mutator(in)
-	}
-}
 
 type DeleteRequestMutator func(*privatepb.DeleteRequest)
 
-func SetDeleteRequest_Id(value string) DeleteRequestMutator {
-	return func(in *privatepb.DeleteRequest) {
-		in.Id = value
-	}
-}
 func ApplyDeleteRequestMutators(in *privatepb.DeleteRequest, mutators []DeleteRequestMutator) {
 	for _, mutator := range mutators {
 		mutator(in)
 	}
 }
 
+func SetDeleteRequest_Id(value string) DeleteRequestMutator {
+	return func(in *privatepb.DeleteRequest) {
+		in.Id = value
+	}
+}
+
 type FetchRequestMutator func(*privatepb.FetchRequest)
+
+func ApplyFetchRequestMutators(in *privatepb.FetchRequest, mutators []FetchRequestMutator) {
+	for _, mutator := range mutators {
+		mutator(in)
+	}
+}
 
 func SetFetchRequest_Id(value string) FetchRequestMutator {
 	return func(in *privatepb.FetchRequest) {
 		in.Id = value
-	}
-}
-func ApplyFetchRequestMutators(in *privatepb.FetchRequest, mutators []FetchRequestMutator) {
-	for _, mutator := range mutators {
-		mutator(in)
 	}
 }
 
@@ -363,6 +366,12 @@ func ApplyListRequestMutators(in *privatepb.ListRequest, mutators []ListRequestM
 
 type UpdateRequestMutator func(*privatepb.UpdateRequest)
 
+func ApplyUpdateRequestMutators(in *privatepb.UpdateRequest, mutators []UpdateRequestMutator) {
+	for _, mutator := range mutators {
+		mutator(in)
+	}
+}
+
 func SetUpdateRequest_Id(value string) UpdateRequestMutator {
 	return func(in *privatepb.UpdateRequest) {
 		in.Id = value
@@ -371,10 +380,5 @@ func SetUpdateRequest_Id(value string) UpdateRequestMutator {
 func SetUpdateRequest_Person(value *privatepb.Person) UpdateRequestMutator {
 	return func(in *privatepb.UpdateRequest) {
 		in.Person = value
-	}
-}
-func ApplyUpdateRequestMutators(in *privatepb.UpdateRequest, mutators []UpdateRequestMutator) {
-	for _, mutator := range mutators {
-		mutator(in)
 	}
 }

--- a/internal/service_mutators_generator.go
+++ b/internal/service_mutators_generator.go
@@ -1,0 +1,11 @@
+package internal
+
+type ServiceMutatorGenerator struct {
+	MessageName string
+	Fields      []MutatorField
+}
+
+type MutatorField struct {
+	FieldName string
+	FieldType string
+}

--- a/internal/templates.go
+++ b/internal/templates.go
@@ -19,6 +19,9 @@ var (
 
 	//go:embed templates/partial_service_method_impl_to_next.go.tmpl
 	templateServiceMethodImpToNext string
+
+	//go:embed templates/partial_service_mutators.go.tmpl
+	templateServiceMutators string
 )
 
 func execute(name string, templateStr string, w io.Writer, params interface{}) error {

--- a/internal/templates/partial_service_mutators.go.tmpl
+++ b/internal/templates/partial_service_mutators.go.tmpl
@@ -1,0 +1,17 @@
+{{ range $message := . }}
+	type {{ .MessageName }}Mutator func(*privatepb.{{ .MessageName }})
+
+	func Apply{{ .MessageName }}Mutators(in *privatepb.{{ .MessageName }}, mutators []{{ .MessageName }}Mutator) {
+		for _, mutator := range mutators {
+			mutator(in)
+		}
+	}
+
+	{{ range $field := .Fields -}}
+		func Set{{ $message.MessageName }}_{{ $field.FieldName }}(value {{ $field.FieldType }}) {{ $message.MessageName }}Mutator {
+			return func(in *privatepb.{{ $message.MessageName }}) {
+				in.{{ $field.FieldName }} = value
+			}
+		}
+	{{ end -}}
+{{ end }}


### PR DESCRIPTION
Partial work for #14

These changes do impact the order in which types, applyer, and setter functions are generated. The order changes to make the template easier to read.