### PR TITLE
Extract validators to use text/template package

### DIFF
--- a/example/proto/go/service/private/service.go
+++ b/example/proto/go/service/private/service.go
@@ -55,10 +55,6 @@ func (s *Service) Update(ctx context.Context, in *privatepb.UpdateRequest) (*pri
 	return s.Impl.Update(ctx, in)
 }
 
-const ValidatorName = "example.private.People.Validator"
-
-func NewValidator() Validator { return validator{} }
-
 type Validator interface {
 	Name() string
 	ValidateCoding(*privatepb.Coding) error
@@ -75,6 +71,11 @@ type Validator interface {
 	ValidateReading(*privatepb.Reading) error
 	ValidateUpdateRequest(*privatepb.UpdateRequest) error
 }
+
+const ValidatorName = "example.private.People.Validator"
+
+func NewValidator() Validator { return validator{} }
+
 type validator struct{}
 
 func (v validator) Name() string { return ValidatorName }
@@ -91,6 +92,9 @@ func (v validator) ValidateCoding(in *privatepb.Coding) error {
 	return nil
 }
 func (v validator) ValidateCreateRequest(in *privatepb.CreateRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,
@@ -137,6 +141,9 @@ func (v validator) ValidateCycling(in *privatepb.Cycling) error {
 	return nil
 }
 func (v validator) ValidateDeleteRequest(in *privatepb.DeleteRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id),
 	)
@@ -146,6 +153,9 @@ func (v validator) ValidateDeleteRequest(in *privatepb.DeleteRequest) error {
 	return nil
 }
 func (v validator) ValidateFetchRequest(in *privatepb.FetchRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id),
 	)
@@ -220,6 +230,9 @@ func (v validator) ValidateHobby_Cycling(in *privatepb.Hobby_Cycling) error {
 	return nil
 }
 func (v validator) ValidateListRequest(in *privatepb.ListRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in)
 	if err != nil {
 		return err
@@ -273,6 +286,9 @@ func (v validator) ValidateReading(in *privatepb.Reading) error {
 	return nil
 }
 func (v validator) ValidateUpdateRequest(in *privatepb.UpdateRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,

--- a/example/proto/go/service/v1/service.go
+++ b/example/proto/go/service/v1/service.go
@@ -31,10 +31,6 @@ type Service struct {
 	publicpb.PeopleServer
 }
 
-const ValidatorName = "example.v1.People.Validator"
-
-func NewValidator() Validator { return validator{} }
-
 type Validator interface {
 	Name() string
 	ValidateBiking(*publicpb.Biking) error
@@ -50,6 +46,11 @@ type Validator interface {
 	ValidatePerson(*publicpb.Person) error
 	ValidateReading(*publicpb.Reading) error
 }
+
+const ValidatorName = "example.v1.People.Validator"
+
+func NewValidator() Validator { return validator{} }
+
 type validator struct{}
 
 func (v validator) Name() string { return ValidatorName }
@@ -78,6 +79,9 @@ func (v validator) ValidateCoding(in *publicpb.Coding) error {
 	return nil
 }
 func (v validator) ValidateCreateRequest(in *publicpb.CreateRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,
@@ -103,6 +107,9 @@ func (v validator) ValidateCreateRequest(in *publicpb.CreateRequest) error {
 	return nil
 }
 func (v validator) ValidateDeleteRequest(in *publicpb.DeleteRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,
@@ -115,6 +122,9 @@ func (v validator) ValidateDeleteRequest(in *publicpb.DeleteRequest) error {
 	return nil
 }
 func (v validator) ValidateGetRequest(in *publicpb.GetRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,
@@ -192,6 +202,9 @@ func (v validator) ValidateHobby_Biking(in *publicpb.Hobby_Biking) error {
 	return nil
 }
 func (v validator) ValidateListRequest(in *publicpb.ListRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in)
 	if err != nil {
 		return err

--- a/example/proto/go/service/v2/service.go
+++ b/example/proto/go/service/v2/service.go
@@ -109,10 +109,6 @@ func (s *Service) UpdateImpl(ctx context.Context, in *publicpb.UpdateRequest, mu
 	return out, privateOut, nil
 }
 
-const ValidatorName = "example.v2.People.Validator"
-
-func NewValidator() Validator { return validator{} }
-
 type Validator interface {
 	Name() string
 	ValidateCoding(*publicpb.Coding) error
@@ -128,6 +124,11 @@ type Validator interface {
 	ValidateReading(*publicpb.Reading) error
 	ValidateUpdateRequest(*publicpb.UpdateRequest) error
 }
+
+const ValidatorName = "example.v2.People.Validator"
+
+func NewValidator() Validator { return validator{} }
+
 type validator struct{}
 
 func (v validator) Name() string { return ValidatorName }
@@ -144,6 +145,9 @@ func (v validator) ValidateCoding(in *publicpb.Coding) error {
 	return nil
 }
 func (v validator) ValidateCreateRequest(in *publicpb.CreateRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,
@@ -178,6 +182,9 @@ func (v validator) ValidateCycling(in *publicpb.Cycling) error {
 	return nil
 }
 func (v validator) ValidateDeleteRequest(in *publicpb.DeleteRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id),
 	)
@@ -187,6 +194,9 @@ func (v validator) ValidateDeleteRequest(in *publicpb.DeleteRequest) error {
 	return nil
 }
 func (v validator) ValidateGetRequest(in *publicpb.GetRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,
@@ -297,6 +307,9 @@ func (v validator) ValidateReading(in *publicpb.Reading) error {
 	return nil
 }
 func (v validator) ValidateUpdateRequest(in *publicpb.UpdateRequest) error {
+	if in == nil {
+		return nil
+	}
 	err := validation.ValidateStruct(in,
 		validation.Field(&in.Id,
 			validation.Required,

--- a/internal/generators/service_validator_interface.go
+++ b/internal/generators/service_validator_interface.go
@@ -1,0 +1,23 @@
+package generators
+
+import (
+	"io"
+
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func NewServiceValidatorInterface(serviceFullName protoreflect.FullName, packageName string, messageNames []string) Generator {
+	return GeneratorFunc(func(w io.Writer) error {
+		return execute("service_validator_interface", templateServiceValidatorInterface, w, serviceValidatorInterface{
+			ServiceFullName: serviceFullName,
+			PackageName:     packageName,
+			MessageNames:    messageNames,
+		})
+	})
+}
+
+type serviceValidatorInterface struct {
+	ServiceFullName protoreflect.FullName
+	PackageName     string
+	MessageNames    []string
+}

--- a/internal/generators/service_validator_method.go
+++ b/internal/generators/service_validator_method.go
@@ -1,0 +1,24 @@
+package generators
+
+import "io"
+
+func NewServiceValidatorMethod(packageName string, messageName string, fields []ValidatorField) Generator {
+	return GeneratorFunc(func(w io.Writer) error {
+		return execute("service_validator_method", templateServiceValidatorMethod, w, ServiceValidatorMethod{
+			PackageName: packageName,
+			MessageName: messageName,
+			Fields:      fields,
+		})
+	})
+}
+
+type ServiceValidatorMethod struct {
+	PackageName string
+	MessageName string
+	Fields      []ValidatorField
+}
+
+type ValidatorField struct {
+	FieldName string
+	Rules     []string
+}

--- a/internal/generators/templates.go
+++ b/internal/generators/templates.go
@@ -20,4 +20,10 @@ var (
 
 	//go:embed templates/partial_service_mutators.go.tmpl
 	templateServiceMutators string
+
+	//go:embed templates/partial_service_validator_interface.go.tmpl
+	templateServiceValidatorInterface string
+
+	//go:embed templates/partial_service_validator_method.go.tmpl
+	templateServiceValidatorMethod string
 )

--- a/internal/generators/templates/partial_service_validator_interface.go.tmpl
+++ b/internal/generators/templates/partial_service_validator_interface.go.tmpl
@@ -1,0 +1,12 @@
+{{ $packageName := .PackageName -}}
+type Validator interface {
+	Name() string
+	{{ range $messageName := .MessageNames -}}
+	Validate{{ $messageName }}(*{{ $packageName }}.{{ $messageName }}) error
+	{{ end -}}
+}
+
+const ValidatorName = "{{ .ServiceFullName }}.Validator"
+func NewValidator() Validator { return validator{} }
+type validator struct {}
+func (v validator) Name() string { return ValidatorName }

--- a/internal/generators/templates/partial_service_validator_method.go.tmpl
+++ b/internal/generators/templates/partial_service_validator_method.go.tmpl
@@ -1,0 +1,18 @@
+func(v validator) Validate{{ .MessageName }}(in *{{ .PackageName }}.{{ .MessageName }}) error {
+	if in == nil {
+		return nil
+	}
+	err := validation.ValidateStruct(in,
+		{{ range .Fields -}}
+		validation.Field(&in.{{ .FieldName }},
+			{{ range .Rules -}}
+			{{ . }},
+			{{ end -}}
+		),
+		{{ end -}}
+	)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Partial work of #14 

The ozzo-validation rules are generated in Go and a slice of strings are passed to the `generators` package. This decision was deliberate to balance complexity between code and the template.